### PR TITLE
fix reputation check

### DIFF
--- a/BOT - Casino.js
+++ b/BOT - Casino.js
@@ -428,7 +428,7 @@ function stackPay(targetMemberNumber, chipsLost) {
 function newCustomer(sender) {
 	customerList[sender.MemberNumber] = new personMagicData()
   customerList[sender.MemberNumber].name = sender.Name
-	if (ReputationCharacterGet(sender,"Dominant")<50) {
+	if (ReputationCharacterGet(sender,"Dominant")<=0) {
 		ServerSend("ChatRoomChat", { Content: sender.Name + ", I am delighted that you decided to enter this casino. You have been chained and if you want to leave here you will have to earn your freedom.", Type: "Chat", Target:sender.MemberNumber} );
 		customerList[sender.MemberNumber].role ='sub'
 	} else {

--- a/BOT - DenialBar.js
+++ b/BOT - DenialBar.js
@@ -417,7 +417,7 @@ function customerRoleDildo(sender, force = false) {
 function newCustomer(sender) {
 	customerList[sender.MemberNumber] = new personMagicData()
   customerList[sender.MemberNumber].name = sender.Name
-	if (ReputationCharacterGet(sender,"Dominant")<=50) {
+	if (ReputationCharacterGet(sender,"Dominant")<=0) {
 		ServerSend("ChatRoomChat", { Content: sender.Name + ", a dildo and a chastity belt have been locked on you, have fun! But not too much or I will punish you.", Type: "Chat", Target:sender.MemberNumber} );
 		customerList[sender.MemberNumber].role ='sub1'
 	} else {


### PR DESCRIPTION
Dominant / Submissive reputation got changed a long time ago.

I believe long time ago the value went from 0 to 100.
Anyone with a stat below 50 was considered submissive and anyone with over 50 was dominant.

The current club uses a value from -100 to +100.
Starting at 0, anyone below 0 is submissive and anyone with more than 0 is dominant. 

This fixes it and for gameplay purposes, consider anyone with a 0 stat to be submissive. For all the new players joining the room.